### PR TITLE
Snowmobile update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-**Underwater Vehicles** allows modular cars, mincopters and scrap transport helicopters to be driven or flown underwater.
+## Features
+
+- Allows vehicles to be used underwater
+- Supports modular cars, snowmobiles, minicopters and scrap transport helicopters
 
 ## Configuration
 
@@ -13,14 +16,14 @@ Default configuration:
     "Snowmobile": false,
     "TomahaSnowmobile": false
   },
-  "ModularCarSettings": {
-    "UnderwaterDragMultiplier": 1.0
+  "UnderwaterDragMultiplier": {
+    "ModularCar": 1.0,
+    "Snowmobile": 1.0,
+    "TomahaSnowmobile": 1.0
   }
 }
 ```
 
-- `AllowedVehicles` -- To enable a particular type of vehicle to be driven or flown underwater, simply change the corresponding option to `true` (and reload the plugin). If you set any option back to `false`, it won't take effect until the next server restart.
-- `ModularCarSettings`
-  - `UnderwaterDragMultiplier` -- This value controls how much drag cars receive for being in water. Set to `1.0` for vanilla drag, `0.0` for no drag. If you want cars to be just a bit slower in water than on land but you think vanilla drag is too much, try a value like `0.25`.
-
-Note: If you unload this plugin for any reason, vehicles that were already spawned will still have underwater capability until the next server restart.
+- `AllowedVehicles` -- Determines whether each type of vehicle can be driven or flown underwater.
+- `UnderwaterDragMultiplier` -- Determines how much drag vehicles receive for being in water. Set to `1.0` for vanilla drag, `0.0` for no drag. Set somewhere between `0.25` and `0.5` to maintain some balance.
+  - Note: Setting this to non-`0` does take a minor performance cost, which gets counted in the plugin's total hook time so that you can monitor it.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Default configuration:
   "AllowedVehicles": {
     "Minicopter": false,
     "ModularCar": false,
-    "ScrapTransportHelicopter": false
+    "ScrapTransportHelicopter": false,
+    "Snowmobile": false,
+    "TomahaSnowmobile": false
   },
   "ModularCarSettings": {
     "UnderwaterDragMultiplier": 1.0

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 - Allows vehicles to be used underwater
 - Supports modular cars, snowmobiles, minicopters and scrap transport helicopters
+- Allows adjusting underwater drag for ground vehicles
 
 ## Configuration
 
@@ -9,21 +10,27 @@ Default configuration:
 
 ```json
 {
-  "AllowedVehicles": {
-    "Minicopter": false,
-    "ModularCar": false,
-    "ScrapTransportHelicopter": false,
-    "Snowmobile": false,
-    "TomahaSnowmobile": false
+  "ModularCar": {
+    "Enabled": false,
+    "DragMultiplier": 1.0
   },
-  "UnderwaterDragMultiplier": {
-    "ModularCar": 1.0,
-    "Snowmobile": 1.0,
-    "TomahaSnowmobile": 1.0
+  "Snowmobile": {
+    "Enabled": false,
+    "DragMultiplier": 1.0
+  },
+  "Tomaha": {
+    "Enabled": false,
+    "DragMultiplier": 1.0
+  },
+  "Minicopter": {
+    "Enabled": false
+  },
+  "ScrapTransportHelicopter": {
+    "Enabled": false
   }
 }
 ```
 
-- `AllowedVehicles` -- Determines whether each type of vehicle can be driven or flown underwater.
-- `UnderwaterDragMultiplier` -- Determines how much drag vehicles receive for being in water. Set to `1.0` for vanilla drag, `0.0` for no drag. Set somewhere between `0.25` and `0.5` to maintain some balance.
+- `Enable` (`true` or `false`) -- Determines whether vehicles of each type can be driven or flown underwater.
+- `DragMultiplier` -- Determines how much drag vehicles receive for being in water. Set to `1.0` for vanilla drag, `0.0` for no drag. Set somewhere between `0.25` and `0.5` to maintain some balance.
   - Note: Setting this to non-`0` does take a minor performance cost, which gets counted in the plugin's total hook time so that you can monitor it.

--- a/UnderwaterVehicles.cs
+++ b/UnderwaterVehicles.cs
@@ -143,7 +143,7 @@ namespace Oxide.Plugins
                     }
                     float throttleDrag = (throttleInput != 0) ? 0 : 0.25f;
                     drag = Mathf.Max(waterFactor, drag);
-                    drag = Mathf.Max(drag, car.carPhysics.GetModifiedDrag());
+                    drag = Mathf.Max(drag, car.GetModifiedDrag());
                     car.rigidBody.drag = Mathf.Max(throttleDrag, drag);
                     car.rigidBody.angularDrag = drag * 0.5f;
                     timeSinceWaterCheck = 0;

--- a/UnderwaterVehicles.cs
+++ b/UnderwaterVehicles.cs
@@ -50,8 +50,6 @@ namespace Oxide.Plugins
 
         private void OnServerInitialized(bool initialBoot)
         {
-            var allowedVehicles = _pluginConfig.AllowedVehicles;
-
             foreach (var entity in BaseNetworkable.serverEntities)
             {
                 var heli = entity as MiniCopter;
@@ -75,9 +73,9 @@ namespace Oxide.Plugins
             var car = vehicle as ModularCar;
             if (car != null)
             {
-                if (_pluginConfig.AllowedVehicles.ModularCar)
+                if (_pluginConfig.ModularCar.Enabled)
                 {
-                    UnderwaterVehicleComponent.AddToVehicle(car, _pluginConfig.DragSettings.ModularCar);
+                    UnderwaterVehicleComponent.AddToVehicle(car, _pluginConfig.ModularCar.DragMultiplier);
                 }
                 return;
             }
@@ -87,16 +85,16 @@ namespace Oxide.Plugins
             {
                 if (snowmobile.ShortPrefabName == "snowmobile")
                 {
-                    if (_pluginConfig.AllowedVehicles.Snowmobile)
+                    if (_pluginConfig.Snowmobile.Enabled)
                     {
-                        UnderwaterVehicleComponent.AddToVehicle(snowmobile, _pluginConfig.DragSettings.Snowmobile);
+                        UnderwaterVehicleComponent.AddToVehicle(snowmobile, _pluginConfig.Snowmobile.DragMultiplier);
                     }
                 }
                 else if (snowmobile.ShortPrefabName == "tomahasnowmobile")
                 {
-                    if (_pluginConfig.AllowedVehicles.TomahaSnowmobile)
+                    if (_pluginConfig.Tomaha.Enabled)
                     {
-                        UnderwaterVehicleComponent.AddToVehicle(snowmobile, _pluginConfig.DragSettings.TomahaSnowmobile);
+                        UnderwaterVehicleComponent.AddToVehicle(snowmobile, _pluginConfig.Tomaha.DragMultiplier);
                     }
                 }
                 return;
@@ -107,12 +105,12 @@ namespace Oxide.Plugins
         {
             if (heli is ScrapTransportHelicopter)
             {
-                if (_pluginConfig.AllowedVehicles.ScrapTransportHelicopter)
+                if (_pluginConfig.ScrapTransportHelicopter.Enabled)
                 {
                     UnderwaterVehicleComponent.AddToVehicle(heli);
                 }
             }
-            else if (_pluginConfig.AllowedVehicles.Minicopter)
+            else if (_pluginConfig.Minicopter.Enabled)
             {
                 UnderwaterVehicleComponent.AddToVehicle(heli);
             }
@@ -247,37 +245,37 @@ namespace Oxide.Plugins
 
         private Configuration GetDefaultConfig() => new Configuration();
 
-        private class AllowedVehiclesConfig
+        private class VehicleConfig
+        {
+            [JsonProperty("Enabled", Order = -3)]
+            public bool Enabled;
+        }
+
+        private class GroundVehicleConfig : VehicleConfig
+        {
+            [JsonProperty("DragMultiplier", Order = -2)]
+            public float DragMultiplier = 1;
+        }
+
+        private class DeprecatedAllowedVehiclesConfig
         {
             [JsonProperty("Minicopter")]
-            public bool Minicopter = false;
+            public bool Minicopter;
 
             [JsonProperty("ModularCar")]
-            public bool ModularCar = false;
+            public bool ModularCar;
 
             [JsonProperty("ScrapTransportHelicopter")]
-            public bool ScrapTransportHelicopter = false;
+            public bool ScrapTransportHelicopter;
 
             [JsonProperty("Snowmobile")]
-            public bool Snowmobile = false;
+            public bool Snowmobile;
 
             [JsonProperty("TomahaSnowmobile")]
-            public bool TomahaSnowmobile = false;
+            public bool TomahaSnowmobile;
         }
 
-        private class DragMultipliers
-        {
-            [JsonProperty("ModularCar")]
-            public float ModularCar = 1;
-
-            [JsonProperty("Snowmobile")]
-            public float Snowmobile = 1;
-
-            [JsonProperty("TomahaSnowmobile")]
-            public float TomahaSnowmobile = 1;
-        }
-
-        private class ModularCarSettings
+        private class DeprecatedModularCarSettings
         {
             [JsonProperty("UnderwaterDragMultiplier")]
             public float UnderwaterDragMultiplier = 1;
@@ -285,16 +283,35 @@ namespace Oxide.Plugins
 
         private class Configuration : SerializableConfiguration
         {
+            [JsonProperty("ModularCar")]
+            public GroundVehicleConfig ModularCar = new GroundVehicleConfig();
+
+            [JsonProperty("Snowmobile")]
+            public GroundVehicleConfig Snowmobile = new GroundVehicleConfig();
+
+            [JsonProperty("Tomaha")]
+            public GroundVehicleConfig Tomaha = new GroundVehicleConfig();
+
+            [JsonProperty("Minicopter")]
+            public VehicleConfig Minicopter = new VehicleConfig();
+
+            [JsonProperty("ScrapTransportHelicopter")]
+            public VehicleConfig ScrapTransportHelicopter = new VehicleConfig();
+
             [JsonProperty("AllowedVehicles")]
-            public AllowedVehiclesConfig AllowedVehicles = new AllowedVehiclesConfig();
+            public DeprecatedAllowedVehiclesConfig AllowedVehicles
+            {
+                set
+                {
+                    ModularCar.Enabled = value.ModularCar;
+                    Minicopter.Enabled = value.Minicopter;
+                    ScrapTransportHelicopter.Enabled = value.ScrapTransportHelicopter;
+                }
+            }
 
-            [JsonProperty("UnderwaterDragMultiplier")]
-            public DragMultipliers DragSettings = new DragMultipliers();
-
-            // Deprecated
             [JsonProperty("ModularCarSettings")]
-            public ModularCarSettings ModularCarSettings
-            { set { DragSettings.ModularCar = value.UnderwaterDragMultiplier; } }
+            public DeprecatedModularCarSettings ModularCarSettings
+            { set { ModularCar.DragMultiplier = value.UnderwaterDragMultiplier; } }
         }
 
         #endregion


### PR DESCRIPTION
- Fixed compile errors due to Rust February 2022 update.
- Added support for snowmobiles, including drag multiplier.
- Water transforms are no longer leaked when vehicles are destroyed.
- Underwater capabilities are now disabled on plugin unload, allowing for simpler uninstallation. This capability may be used in the future to restrict underwater vehicle usage based on the permissions of the vehicle occupants, if there is sufficient interest.
- Restructured the config. Your config will be automatically migrated to the new format without losing your previous settings.